### PR TITLE
🐛Bugfix(requestData): #131

### DIFF
--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -32,6 +32,7 @@ const login = (req: Request, res: Response, next: NextFunction) => {
       httpOnly: true,
     });
     return res.status(200).json({
+      userInfo: userInfo,
       message: "Success Login ",
     });
   })(req, res, next); // 미들웨어 내의 미들웨어에는 (req, res, next)를 붙입니다.


### PR DESCRIPTION
## 개요
#131 question list 페이지의 question 의 수 일정하지 않은 버그 해결
## 작업사항
- hashtag join문 제거
- hashtag get 하여 response data에 추가
- #129에서 잘못삭제한 로그인api response data의 userInfo 추가
## 변경로직
- question get할때 hashtag join하는 로직에서 question get 한 뒤에 반복문을 통해 questionId를 이용하여 hashtag get하여 직접 hashtag data 추가하는 로직으로 변경