### PR TITLE
➕add(answer_count): add 'answer_count' column to question table

### DIFF
--- a/backend/ormconfig.ts
+++ b/backend/ormconfig.ts
@@ -8,7 +8,7 @@ export = {
 	username: process.env.MYSQL_USER,
 	password: process.env.MYSQL_ROOT_PASSWORD,
 	database: process.env.MYSQL_DATABASE,
-	synchronize: true,
+	synchronize: false,
 	logging: false,
 	entities: ["src/entity/**/*.ts"],
 	migrations: ["src/migration/**/*.ts"],

--- a/backend/src/controllers/answer.ts
+++ b/backend/src/controllers/answer.ts
@@ -6,7 +6,8 @@ dotenv.config();
 import { AnswerService } from '../service/answer_service';
 
 const deleteAnswer = async (req: DecodedRequest, res: Response) => {
-	const { answerId, questionId } = req.body;
+	const questionId = Number(req.query.questionId);
+	const answerId = Number(req.query.answerId);
 	const userId = req.decodedId;
 	const answerService = new AnswerService();
 	try {

--- a/backend/src/controllers/question.ts
+++ b/backend/src/controllers/question.ts
@@ -7,7 +7,7 @@ import { DecodedRequest } from '../definition/decoded_jwt'
 import { QuestionService } from '../service/question_service';
 
 const deleteQuestion = async (req: DecodedRequest, res: Response, next: NextFunction) => {
-    const { questionId } = req.body;
+    const questionId = Number(req.query.questionId);
     const userId: number = req.decodedId;
     const questionService: QuestionService = new QuestionService();
 

--- a/backend/src/entity/question.ts
+++ b/backend/src/entity/question.ts
@@ -36,6 +36,9 @@ export class Question extends Base {
     is_solved: boolean;
 
     @Column({ default: 0 })
+    answer_count: number;
+
+    @Column({ default: 0 })
     like_count: number;
 
     @Column({ default: 0 })

--- a/backend/src/service/answer_service.ts
+++ b/backend/src/service/answer_service.ts
@@ -39,6 +39,8 @@ export class AnswerService {
 
 		await this.queryRunner.startTransaction();
 		try {
+			question.answer_count += 1;
+			await this.questionRepository.save(question);
 			const answer = await this.answerRepository.save(answerInfo);
 			// await Promise.all(photos.map(async (photo) => {
 			// 	await this.photoRepository.save({ photo, question, answer });
@@ -108,15 +110,17 @@ export class AnswerService {
 				where: { id: answerId, user: { id: userId }, question: { id: questionId } },
 				relations: ['user', 'question']
 			});
+		const question = await this.questionRepository
+			.findOne({ where: { id: questionId } });
 		if (answer === undefined) {
-			const question = await this.questionRepository
-				.findOne({ where: { id: questionId } });
+
 			const noAuthAnswer = await this.answerRepository
 				.findOne({
 					where: { id: answerId, question: { id: questionId } },
 					relations: ['question']
 				});
 			if (question === undefined) {
+				console.log(question);
 				await this.queryRunner.release();
 				throw new Error("The questionPost doesn't exist.");
 			}
@@ -131,6 +135,8 @@ export class AnswerService {
 		}
 		await this.queryRunner.startTransaction();
 		try {
+			question.answer_count -= 1;
+			await this.questionRepository.save(question);
 			await this.answerRepository.remove(answer);
 			await this.queryRunner.commitTransaction();
 		} catch (error) {

--- a/backend/src/service/hashtag_service.ts
+++ b/backend/src/service/hashtag_service.ts
@@ -23,7 +23,7 @@ export class HashtagService {
             .leftJoinAndSelect('question.user', 'question_user')
             .leftJoin('question.hashtag', 'hashtag')
             .where('hashtag.name = :name', { name: pageInfo.hashtag })
-            .select(['question.id', 'question.created_at', 'question.is_solved', 'question.like_count', 'question.view_count', 'question.title', 'question.text',
+            .select(['question.id', 'question.created_at', 'question.is_solved', 'question.like_count', 'question.view_count', 'question.answer_count', 'question.title', 'question.text',
                 'question_user.id', 'question_user.created_at', 'question_user.email', 'question_user.nickname', 'question_user.photo',
             ])
             .orderBy('question.id', 'DESC')
@@ -55,5 +55,4 @@ export class HashtagService {
     async postHashTag(): Promise<any> {
 
     }
-
 }

--- a/backend/src/service/page_service.ts
+++ b/backend/src/service/page_service.ts
@@ -52,7 +52,7 @@ export class PageService {
 		const questionList = await this.questionRepository
 			.createQueryBuilder('question')
 			.leftJoinAndSelect('question.user', 'question_user')
-			.select(['question.id', 'question.created_at', 'question.is_solved', 'question.like_count', 'question.view_count', 'question.title', 'question.text',
+			.select(['question.id', 'question.created_at', 'question.is_solved', 'question.like_count', 'question.view_count', 'question.answer_count', 'question.title', 'question.text',
 				'question_user.id', 'question_user.created_at', 'question_user.email', 'question_user.nickname', 'question_user.photo',
 			])
 			.orderBy('question.id', 'DESC')


### PR DESCRIPTION
## 개요
#137 question 테이블에 answer_count 컬럼 추가

## 작업사항
- question 테이블에 answer_count 컬럼 추가
- answer create delete 시 answer_count 증가 감소 코드 추가
- mainpage question, hashtag question 응답할 때 answer_count 포함
- question delete, answer delete시 request data 를 쿼리에서 읽어오도록 수정

## 변경로직
- question의 컬럼이 변경됨 => #99 DB 리셋 필요