### PR TITLE
🐛 bugFix : add guestId for refresh and change refresh logic

### DIFF
--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -82,8 +82,8 @@ const signup = async (req: any, res: Response) => {
 			const guestId = uuidv4();
 			const accessToken = jwtUtil.accessSign(newUser.id);
 			const refreshToken = jwtUtil.refreshSign();
-			redisClient.set(guestId, newUser.id);
-			redisClient.set(newUser.id, refreshToken);
+			redisClient.set(guestId, newUser.id, 'EX', 60 * 60 * 24 * 14);
+			redisClient.set(newUser.id, refreshToken, 'EX', 60 * 60 * 24 * 14);
 
 			res.cookie("guestId", guestId, {
 			maxAge: 60000 * 60 * 24 * 14,
@@ -132,8 +132,8 @@ const FourtyTowLogin = (req: Request, res: Response, next: NextFunction) => {
 		const guestId = uuidv4();
 		const accessToken = jwtUtil.accessSign(user.id);
 		const refreshToken = jwtUtil.refreshSign();
-		redisClient.set(user.id, refreshToken);
-		redisClient.set(guestId, user.id);
+		redisClient.set(guestId, user.id, 'EX', 60 * 60 * 24 * 14);
+		redisClient.set(user.id, refreshToken, 'EX', 60 * 60 * 24 * 14);
 		res.cookie("guestId", guestId, {
 			maxAge: 60000 * 60 * 24 * 14,
 			httpOnly: true,

--- a/backend/src/controllers/auth.ts
+++ b/backend/src/controllers/auth.ts
@@ -4,6 +4,7 @@ dotenv.config();
 import { Request, Response, NextFunction } from 'express';
 import passport from "passport";
 import bcrypt from "bcrypt";
+import { v4 as uuidv4 } from 'uuid';
 
 import { jwtUtil } from "../jwt-util/jwt_utils";
 import { redisClient } from "../lib/redis";
@@ -24,9 +25,17 @@ const login = (req: Request, res: Response, next: NextFunction) => {
 			photo: photo,
 			nickname: user.nickname
 		}
-		const accessToken = jwtUtil.accessSign(user);
+		const guestId = uuidv4();
+		const accessToken = jwtUtil.accessSign(user.id);
 		const refreshToken = jwtUtil.refreshSign();
-		redisClient.set(user.id, refreshToken);
+
+		redisClient.set(guestId, user.id, 'EX', 60 * 60 * 24 * 14);
+		redisClient.set(user.id, refreshToken, 'EX', 60 * 60 * 24 * 14);
+
+		res.cookie("guestId", guestId, {
+			maxAge: 60000 * 60 * 24 * 14,
+			httpOnly: true,
+			});
 		res.cookie("refresh", refreshToken, {
 			maxAge: 60000 * 60 * 24 * 14,
 			httpOnly: true,
@@ -70,8 +79,17 @@ const signup = async (req: any, res: Response) => {
 				photo: newUser.photo,
 				nickname: newUser.nickname
 			}
-			const accessToken = jwtUtil.accessSign(newUser);
+			const guestId = uuidv4();
+			const accessToken = jwtUtil.accessSign(newUser.id);
 			const refreshToken = jwtUtil.refreshSign();
+			redisClient.set(guestId, newUser.id);
+			redisClient.set(newUser.id, refreshToken);
+
+			res.cookie("guestId", guestId, {
+			maxAge: 60000 * 60 * 24 * 14,
+			httpOnly: true,
+			});
+
 			res.cookie("refresh", refreshToken, {
 				maxAge: 60000 * 60 * 24 * 14,
 				httpOnly: true,
@@ -79,7 +97,7 @@ const signup = async (req: any, res: Response) => {
 			res.cookie("authorization", accessToken, {
 				maxAge: 60000 * 30,
 				httpOnly: true,
-			});
+			})
 			res.status(200).json({
 				result: true,
 				message: "signup successful",
@@ -111,9 +129,15 @@ const FourtyTowLogin = (req: Request, res: Response, next: NextFunction) => {
 			photo: photo,
 			nickname: user.nickname
 		}
-		const accessToken = jwtUtil.accessSign(user);
+		const guestId = uuidv4();
+		const accessToken = jwtUtil.accessSign(user.id);
 		const refreshToken = jwtUtil.refreshSign();
 		redisClient.set(user.id, refreshToken);
+		redisClient.set(guestId, user.id);
+		res.cookie("guestId", guestId, {
+			maxAge: 60000 * 60 * 24 * 14,
+			httpOnly: true,
+		});
 		res.cookie("refresh", refreshToken, {
 			maxAge: 60000 * 60 * 24 * 14,
 			httpOnly: true,

--- a/backend/src/controllers/question.ts
+++ b/backend/src/controllers/question.ts
@@ -49,7 +49,8 @@ const updateQuestion = async (req: DecodedRequest, res: Response, next: NextFunc
 const uploadQuestion = async (req: DecodedRequest, res: Response) => {
     const userId: number = req.decodedId
     const { title, text, hashtag } = req.body;
-    console.log(req.body)
+    console.log(userId)
+
     const questionService: QuestionService = new QuestionService();
     try {
         const id = await questionService.post({ title, text, userId, hashtag });

--- a/backend/src/jwt-util/jwt_utils.ts
+++ b/backend/src/jwt-util/jwt_utils.ts
@@ -8,9 +8,9 @@ import { redisClient } from "../lib/redis";
 
 const secret = process.env.TOKEN_SECRET_KEY;
 
-const accessSign = (user) => {
+const accessSign = (userId) => {
   const payload = {
-    id: user.id,
+    id: userId,
   };
   return jwt.sign(payload, secret, {
     expiresIn: "30m",

--- a/backend/src/middlewares/auth.middleware.ts
+++ b/backend/src/middlewares/auth.middleware.ts
@@ -4,21 +4,29 @@ import { jwtUtil } from "../jwt-util/jwt_utils";
 import { refresh } from "../jwt-util/refresh";
 import { DecodedRequest } from "../definition/decoded_jwt";
 
-export const authJwt = (req: DecodedRequest, res: Response, next: NextFunction) => {
+export const authJwt = async (req: DecodedRequest, res: Response, next: NextFunction) => {
   const access_token = req.cookies.authorization;
   const refresh_token = req.cookies.refresh;
   const result = jwtUtil.accessVerify(access_token);
   if (result.ok) {
     req.decodedId = result.id;
     next();
-  } else {
-    refresh(req, res);
-    // res.status(401).json({
-    //   message: result.message,
-    // });
+  }
+  else {
+    try {
+      const userId = await refresh(req, res);
+      req.decodedId = userId;
+      next();
+    }
+    catch(error){
+      console.log(error)
+      return res.status(500).json({
+        result: false,
+        message: `An error occurred (${error.message})`
+      })
+    }
   }
 };
-
 
 export const checkUserIsLogin = (req: DecodedRequest, res: Response, next: NextFunction) => {
   const access_token = req.cookies.authorization;


### PR DESCRIPTION
## 개요
#210 쿠키에 게스트 아이디 추가 및 리프레시 로직 변경

## 작업사항
- 로그인, 회원가입시 쿠키에 게스트 아이디 추가
- 리프레시 토큰으로 엑세스 토큰 재발급시 쿠키에 있는 게스트 아이디를 레디스에서 키로 사용하여 유저 아이디를 벨류로 얻어와서 엑세스 토큰의 페이로드에 유저아이디 추가
- 레디스에 저장하는 리프레시 토큰과 게스트아이디 만료기간 설정 (14일)

## 변경로직
- 리프레시 토큰으로 엑세스 토큰 재발급시 쿠키에 있는 게스트 아이디를 레디스에서 키로 사용하여 유저 아이디를 벨류로 얻어와서 엑세스 토큰의 페이로드에 유저아이디 추가
