### PR TITLE
해시태그 아이디로 질문글 리스트 가져오기 API 작성

### DIFF
--- a/backend/build/swagger.yaml
+++ b/backend/build/swagger.yaml
@@ -692,6 +692,7 @@ paths:
       summary: 해시태그 아이디로 질문글 리스트를 반환합니다.
       tags:
         - page
+      description: '데이터를 최신순으로 정렬하려면 orderBy = "time", 좋아요 순으로 정렬하려면 "like", 해결되지 않은 질문 리스트를 응답 받으려면 "solving" 사용'
       parameters:
         - name: pageNumber
           in: query
@@ -706,6 +707,12 @@ paths:
             type: integer
             format: int64
           example: 1
+          required: true
+        - name: orderBy
+          in: query
+          schema:
+            type: string
+          example: time
           required: true
       responses:
         '200':

--- a/backend/build/swagger.yaml
+++ b/backend/build/swagger.yaml
@@ -687,7 +687,7 @@ paths:
                 $ref: '#/components/schemas/MainPage'
         '404':
           description: Page doesn't exist
-  /pages/list/question/hashtag:
+  /pages/list/question/hashtag/id:
     get:
       summary: 해시태그 아이디로 질문글 리스트를 반환합니다.
       tags:
@@ -707,6 +707,41 @@ paths:
             type: integer
             format: int64
           example: 1
+          required: true
+        - name: orderBy
+          in: query
+          schema:
+            type: string
+          example: time
+          required: true
+      responses:
+        '200':
+          description: 페이지 요청 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MainPage'
+        '404':
+          description: Page doesn't exist
+  /pages/list/question/hashtag/name:
+    get:
+      summary: 해시태그 이름으로 질문글 리스트를 반환합니다.
+      tags:
+        - page
+      description: '데이터를 최신순으로 정렬하려면 orderBy = "time", 좋아요 순으로 정렬하려면 "like", 해결되지 않은 질문 리스트를 응답 받으려면 "solving" 사용'
+      parameters:
+        - name: pageNumber
+          in: query
+          schema:
+            type: integer
+            format: int64
+          example: 1
+          required: true
+        - name: hashtagName
+          in: query
+          schema:
+            type: string
+          example: ft_printf
           required: true
         - name: orderBy
           in: query

--- a/backend/build/swagger.yaml
+++ b/backend/build/swagger.yaml
@@ -687,6 +687,35 @@ paths:
                 $ref: '#/components/schemas/MainPage'
         '404':
           description: Page doesn't exist
+  /pages/list/question/hashtag:
+    get:
+      summary: 해시태그 아이디로 질문글 리스트를 반환합니다.
+      tags:
+        - page
+      parameters:
+        - name: pageNumber
+          in: query
+          schema:
+            type: integer
+            format: int64
+          example: 1
+          required: true
+        - name: hashtagId
+          in: query
+          schema:
+            type: integer
+            format: int64
+          example: 1
+          required: true
+      responses:
+        '200':
+          description: 페이지 요청 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MainPage'
+        '404':
+          description: Page doesn't exist
   /pages/list/question/like:
     get:
       summary: 질문 리스트를 추천순으로 반환합니다.

--- a/backend/src/controllers/page.ts
+++ b/backend/src/controllers/page.ts
@@ -97,6 +97,29 @@ const getQuestionListPageByKeyword = async (req: any, res: Response, next: NextF
 	}
 }
 
+const getQuestionListPageByHashtagId = async (req: any, res: Response, next: NextFunction) => {
+	const pageNumber = Number(req.query.pageNumber) - 1;
+	const hashtagId = req.query.hashtagId;
+	const limit = 8;
+	const offset = pageNumber * limit;
+	const pageInfo = { limit, offset, hashtagId };
+	const pageService: PageService = new PageService();
+
+	try {
+		const { questionList, questionCount } = await pageService.getQuestionListByHashtagId(pageInfo);
+		return res.status(200).json({
+			quesiontList: questionList,
+			questionCount: questionCount,
+			message: "getList success",
+		})
+	} catch (error) {
+		console.log(error);
+		return res.status(500).json({
+			message: `An error occurred (${error.message})`
+		})
+	}
+}
+
 const getQuestionDetailPage = async (req: DecodedRequest, res: Response, next: NextFunction) => {
 	const questionId = Number(req.query.questionId);
 	const userId = req.decodedId;
@@ -140,5 +163,5 @@ const increaseQuestionViewCount = async (req: any, res: Response, next: NextFunc
 
 export const PageController = {
 	getQuestionListPage, getQuestionDetailPage, getQuestionListPageOrderByLike, getQuestionListPageUnsolved,
-	getQuestionListPageByKeyword, increaseQuestionViewCount
+	getQuestionListPageByKeyword, getQuestionListPageByHashtagId, increaseQuestionViewCount
 }

--- a/backend/src/controllers/page.ts
+++ b/backend/src/controllers/page.ts
@@ -121,6 +121,30 @@ const getQuestionListPageByHashtagId = async (req: any, res: Response, next: Nex
 	}
 }
 
+const getQuestionListPageByHashtagName = async (req: any, res: Response, next: NextFunction) => {
+	const pageNumber = Number(req.query.pageNumber) - 1;
+	const hashtagName = req.query.hashtagName;
+	const orderBy = req.query.orderBy;
+	const limit = 8;
+	const offset = pageNumber * limit;
+	const pageInfo = { limit, offset, hashtagName };
+	const pageService: PageService = new PageService();
+
+	try {
+		const { questionList, questionCount } = await pageService.getQuestionListByHashtagName(pageInfo, orderBy);
+		return res.status(200).json({
+			quesiontList: questionList,
+			questionCount: questionCount,
+			message: "getList success",
+		})
+	} catch (error) {
+		console.log(error);
+		return res.status(500).json({
+			message: `An error occurred (${error.message})`
+		})
+	}
+}
+
 const getQuestionDetailPage = async (req: DecodedRequest, res: Response, next: NextFunction) => {
 	const questionId = Number(req.query.questionId);
 	const userId = req.decodedId;
@@ -164,5 +188,5 @@ const increaseQuestionViewCount = async (req: any, res: Response, next: NextFunc
 
 export const PageController = {
 	getQuestionListPage, getQuestionDetailPage, getQuestionListPageOrderByLike, getQuestionListPageUnsolved,
-	getQuestionListPageByKeyword, getQuestionListPageByHashtagId, increaseQuestionViewCount
+	getQuestionListPageByKeyword, getQuestionListPageByHashtagId, getQuestionListPageByHashtagName, increaseQuestionViewCount
 }

--- a/backend/src/controllers/page.ts
+++ b/backend/src/controllers/page.ts
@@ -100,13 +100,14 @@ const getQuestionListPageByKeyword = async (req: any, res: Response, next: NextF
 const getQuestionListPageByHashtagId = async (req: any, res: Response, next: NextFunction) => {
 	const pageNumber = Number(req.query.pageNumber) - 1;
 	const hashtagId = req.query.hashtagId;
+	const orderBy = req.query.orderBy;
 	const limit = 8;
 	const offset = pageNumber * limit;
 	const pageInfo = { limit, offset, hashtagId };
 	const pageService: PageService = new PageService();
 
 	try {
-		const { questionList, questionCount } = await pageService.getQuestionListByHashtagId(pageInfo);
+		const { questionList, questionCount } = await pageService.getQuestionListByHashtagId(pageInfo, orderBy);
 		return res.status(200).json({
 			quesiontList: questionList,
 			questionCount: questionCount,

--- a/backend/src/routes/page.ts
+++ b/backend/src/routes/page.ts
@@ -15,6 +15,8 @@ pageRouter.get('/list/question/unsolved', PageController.getQuestionListPageUnso
 
 pageRouter.get('/list/question/keyword', PageController.getQuestionListPageByKeyword);
 
+pageRouter.get('/list/question/hashtag', PageController.getQuestionListPageByHashtagId);
+
 pageRouter.post('/question/viewCount', PageController.increaseQuestionViewCount);
 
 // router.delete('/delete', authticate_JWT, s3.s3DeletePhoto, QuestionController.deleteQuestion)

--- a/backend/src/routes/page.ts
+++ b/backend/src/routes/page.ts
@@ -15,7 +15,9 @@ pageRouter.get('/list/question/unsolved', PageController.getQuestionListPageUnso
 
 pageRouter.get('/list/question/keyword', PageController.getQuestionListPageByKeyword);
 
-pageRouter.get('/list/question/hashtag', PageController.getQuestionListPageByHashtagId);
+pageRouter.get('/list/question/hashtag/id', PageController.getQuestionListPageByHashtagId);
+
+pageRouter.get('/list/question/hashtag/name', PageController.getQuestionListPageByHashtagName);
 
 pageRouter.post('/question/viewCount', PageController.increaseQuestionViewCount);
 

--- a/backend/src/service/page_service.ts
+++ b/backend/src/service/page_service.ts
@@ -5,7 +5,6 @@ import { HashTag } from "../entity/hashtag";
 import { Question } from "../entity/question";
 import { QuestionLike } from "../entity/question_like";
 import { AnswerLike } from "../entity/answer_like";
-import { length } from "class-validator";
 import { QuestionDetail } from "../definition/response_data";
 import { AnswerDetail } from "../definition/response_data";
 
@@ -13,11 +12,13 @@ export class PageService {
 	private questionRepository: Repository<Question>;
 	private questionLikeRepository: Repository<QuestionLike>;
 	private answerLikeRepository: Repository<AnswerLike>;
+	private hashtagRepository: Repository<HashTag>;
 
 	constructor() {
 		this.questionRepository = getConnection().getRepository(Question);
 		this.questionLikeRepository = getConnection().getRepository(QuestionLike);
 		this.answerLikeRepository = getConnection().getRepository(AnswerLike);
+		this.hashtagRepository = getConnection().getRepository(HashTag);
 	}
 
 	async setQuestionViewCount(questionId) {
@@ -337,4 +338,37 @@ export class PageService {
 			.getCount();
 		return { questionList, questionCount }
 	}
+
+	async getQuestionListByHashtagId(pageInfo): Promise<any> {
+        const subQuery = await this.questionRepository
+            .createQueryBuilder('covers')
+            .select(['covers.id'])
+            .leftJoin('covers.hashtag', 'hashtag')
+            .where('hashtag.id = :id', { id: pageInfo.hashtagId })
+            .orderBy('covers.id', 'DESC')
+            .limit(pageInfo.limit)
+            .offset(pageInfo.offset)
+
+        const questionList = await this.questionRepository
+            .createQueryBuilder('question')
+            .innerJoin(`(${subQuery.getQuery()})`, 'covers',
+                'question.id = covers.covers_id')
+            .setParameters(subQuery.getParameters())
+            .innerJoinAndSelect('question.user', 'question_user')
+            .leftJoin('question.hashtag', 'question_hashtag')
+            .select(['question.id', 'question.created_at', 'question.is_solved', 'question.like_count', 'question.view_count', 'question.answer_count', 'question.title', 'question.text',
+                'question_user.id', 'question_user.created_at', 'question_user.email', 'question_user.nickname', 'question_user.photo',
+                'question_hashtag.id', 'question_hashtag.name'
+            ])
+            .getMany();
+
+        const questionCount = await await this.hashtagRepository
+            .createQueryBuilder('hashtag')
+            .leftJoinAndSelect('hashtag.question', 'question')
+            .where('hashtag.name = :name', { name: pageInfo.hashtag })
+            .select('COUNT(*) AS count')
+            .getRawOne();
+
+        return { questionList, questionCount: questionCount.count };
+    }
 }

--- a/backend/src/service/page_service.ts
+++ b/backend/src/service/page_service.ts
@@ -385,7 +385,7 @@ export class PageService {
             ])
             .getMany();
 
-        const questionCount = await await this.hashtagRepository
+        const questionCount = await this.hashtagRepository
             .createQueryBuilder('hashtag')
             .leftJoinAndSelect('hashtag.question', 'question')
             .where('hashtag.name = :name', { name: pageInfo.hashtag })

--- a/backend/src/service/page_service.ts
+++ b/backend/src/service/page_service.ts
@@ -394,4 +394,60 @@ export class PageService {
 
         return { questionList, questionCount: questionCount.count };
     }
+
+	async getQuestionListByHashtagName(pageInfo, orderBy): Promise<any> {
+		let subQuery;
+
+        subQuery = await this.questionRepository
+            .createQueryBuilder('covers')
+            .select(['covers.id'])
+            .leftJoin('covers.hashtag', 'hashtag')
+            .where('hashtag.name = :name', { name: pageInfo.hashtagName })
+	
+		if (orderBy === "time"){
+			subQuery.select(['covers.id'])
+				.orderBy('covers.id', 'DESC')
+				.limit(pageInfo.limit)
+				.offset(pageInfo.offset)
+		}
+		else if (orderBy === "like"){
+			subQuery
+				.select(['covers.id', 'covers.like_count'])
+				.orderBy('covers.like_count', 'DESC')
+				.addOrderBy('covers.id', 'DESC')
+				.limit(pageInfo.limit)
+				.offset(pageInfo.offset)
+		}
+	
+		else if (orderBy === "solving"){
+			subQuery 
+				.select(['covers.id', 'covers.like_count'])
+				.andWhere('covers.is_solved = :is_solved', { is_solved: false })
+				.addOrderBy('covers.id', 'DESC')
+				.limit(pageInfo.limit)
+				.offset(pageInfo.offset)
+		}
+
+        const questionList = await this.questionRepository
+            .createQueryBuilder('question')
+            .innerJoin(`(${subQuery.getQuery()})`, 'covers',
+                'question.id = covers.covers_id')
+            .setParameters(subQuery.getParameters())
+            .innerJoinAndSelect('question.user', 'question_user')
+            .leftJoin('question.hashtag', 'question_hashtag')
+            .select(['question.id', 'question.created_at', 'question.is_solved', 'question.like_count', 'question.view_count', 'question.answer_count', 'question.title', 'question.text',
+                'question_user.id', 'question_user.created_at', 'question_user.email', 'question_user.nickname', 'question_user.photo',
+                'question_hashtag.id', 'question_hashtag.name'
+            ])
+            .getMany();
+
+        const questionCount = await await this.hashtagRepository
+            .createQueryBuilder('hashtag')
+            .leftJoinAndSelect('hashtag.question', 'question')
+            .where('hashtag.name = :name', { name: pageInfo.hashtag })
+            .select('COUNT(*) AS count')
+            .getRawOne();
+
+        return { questionList, questionCount: questionCount.count };
+    }
 }

--- a/backend/src/service/page_service.ts
+++ b/backend/src/service/page_service.ts
@@ -339,15 +339,38 @@ export class PageService {
 		return { questionList, questionCount }
 	}
 
-	async getQuestionListByHashtagId(pageInfo): Promise<any> {
-        const subQuery = await this.questionRepository
+	async getQuestionListByHashtagId(pageInfo, orderBy): Promise<any> {
+		let subQuery;
+
+        subQuery = await this.questionRepository
             .createQueryBuilder('covers')
             .select(['covers.id'])
             .leftJoin('covers.hashtag', 'hashtag')
             .where('hashtag.id = :id', { id: pageInfo.hashtagId })
-            .orderBy('covers.id', 'DESC')
-            .limit(pageInfo.limit)
-            .offset(pageInfo.offset)
+	
+		if (orderBy === "time"){
+			subQuery.select(['covers.id'])
+				.orderBy('covers.id', 'DESC')
+				.limit(pageInfo.limit)
+				.offset(pageInfo.offset)
+		}
+		else if (orderBy === "like"){
+			subQuery
+				.select(['covers.id', 'covers.like_count'])
+				.orderBy('covers.like_count', 'DESC')
+				.addOrderBy('covers.id', 'DESC')
+				.limit(pageInfo.limit)
+				.offset(pageInfo.offset)
+		}
+	
+		else if (orderBy === "solving"){
+			subQuery 
+				.select(['covers.id', 'covers.like_count'])
+				.andWhere('covers.is_solved = :is_solved', { is_solved: false })
+				.addOrderBy('covers.id', 'DESC')
+				.limit(pageInfo.limit)
+				.offset(pageInfo.offset)
+		}
 
         const questionList = await this.questionRepository
             .createQueryBuilder('question')

--- a/backend/src/swagger/openapi.yaml
+++ b/backend/src/swagger/openapi.yaml
@@ -720,6 +720,7 @@ paths:
       summary: 해시태그 아이디로 질문글 리스트를 반환합니다.
       tags:
         - page
+      description: 데이터를 최신순으로 정렬하려면 orderBy = "time", 좋아요 순으로 정렬하려면 "like", 해결되지 않은 질문 리스트를 응답 받으려면 "solving" 사용
       parameters:
         - name: pageNumber
           in: query
@@ -734,6 +735,12 @@ paths:
             type: integer
             format: int64
           example: 1
+          required: true
+        - name: orderBy
+          in: query
+          schema:
+            type: string
+          example: time
           required: true
       responses:
         "200":

--- a/backend/src/swagger/openapi.yaml
+++ b/backend/src/swagger/openapi.yaml
@@ -715,6 +715,36 @@ paths:
         "404":
           description: Page doesn't exist
 
+  /pages/list/question/hashtag:
+    get:
+      summary: 해시태그 아이디로 질문글 리스트를 반환합니다.
+      tags:
+        - page
+      parameters:
+        - name: pageNumber
+          in: query
+          schema:
+            type: integer
+            format: int64
+          example: 1
+          required: true
+        - name: hashtagId
+          in: query
+          schema:
+            type: integer
+            format: int64
+          example: 1
+          required: true
+      responses:
+        "200":
+          description: 페이지 요청 성공
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MainPage"
+        "404":
+          description: Page doesn't exist
+
   /pages/list/question/like:
     get:
       summary: 질문 리스트를 추천순으로 반환합니다.

--- a/backend/src/swagger/openapi.yaml
+++ b/backend/src/swagger/openapi.yaml
@@ -715,7 +715,7 @@ paths:
         "404":
           description: Page doesn't exist
 
-  /pages/list/question/hashtag:
+  /pages/list/question/hashtag/id:
     get:
       summary: 해시태그 아이디로 질문글 리스트를 반환합니다.
       tags:
@@ -735,6 +735,42 @@ paths:
             type: integer
             format: int64
           example: 1
+          required: true
+        - name: orderBy
+          in: query
+          schema:
+            type: string
+          example: time
+          required: true
+      responses:
+        "200":
+          description: 페이지 요청 성공
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MainPage"
+        "404":
+          description: Page doesn't exist
+
+  /pages/list/question/hashtag/name:
+    get:
+      summary: 해시태그 이름으로 질문글 리스트를 반환합니다.
+      tags:
+        - page
+      description: 데이터를 최신순으로 정렬하려면 orderBy = "time", 좋아요 순으로 정렬하려면 "like", 해결되지 않은 질문 리스트를 응답 받으려면 "solving" 사용
+      parameters:
+        - name: pageNumber
+          in: query
+          schema:
+            type: integer
+            format: int64
+          example: 1
+          required: true
+        - name: hashtagName
+          in: query
+          schema:
+            type: string
+          example: ft_printf
           required: true
         - name: orderBy
           in: query


### PR DESCRIPTION
## 개요
해시태그 아이디로 질문글 리스트 가져오기 API 작성
## 작업사항
- 해시태그 아이디로 질문글 리스트 가져오기 API 작성
- 해시태그 아이디로 질문글 리스트 가져오기 API swagger 작성
- 해시태그 아이디로 질문글 리스트 가져오기 API 에서 orderBy 쿼리스트링으로 정렬 방식 선택하도록 수정

## 변경로직
- 내용을 적어주세요.
