### PR TITLE
:bug:잘못된 questionCount 응답 수정

### DIFF
--- a/backend/src/jwt-util/refresh.ts
+++ b/backend/src/jwt-util/refresh.ts
@@ -11,26 +11,26 @@ export const refresh = async (req: DecodedRequest, res: Response) => {
   const refresh_token = req.cookies.refresh;
   const guestId = req.cookies.guestId;
   if (refresh_token && guestId) {
-      const getAsync = util.promisify(redisClient.get).bind(redisClient);
-      const userId = await getAsync(guestId);
-      const refreshResult = await jwtUtil.refreshVerify(refresh_token, userId);
+    const getAsync = util.promisify(redisClient.get).bind(redisClient);
+    const userId = await getAsync(guestId);
+    const refreshResult = await jwtUtil.refreshVerify(refresh_token, userId);
 
-      //refresh token 만료됬을 경우
-      if (refreshResult === false) {
-        throw new UnauthorizedException("refresh token is expired.");
-      }
-      // refresh token은 만료되지 않은 경우
-      else {
-        const newAccesToken = jwtUtil.accessSign(userId);
-        res.cookie("authorization", newAccesToken, {
-          maxAge: 60000 * 30,
-          httpOnly: true,
-        });
-        return userId;
-      }
+    //refresh token 만료됬을 경우
+    if (refreshResult === false) {
+      throw new UnauthorizedException("refresh token is expired.");
+    }
+    // refresh token은 만료되지 않은 경우
+    else {
+      const newAccesToken = jwtUtil.accessSign(userId);
+      res.cookie("authorization", newAccesToken, {
+        maxAge: 60000 * 30,
+        httpOnly: true,
+      });
+      return userId;
+    }
   }
   // guest id 또는 refresh token이 헤더에 없는 경우
   else {
-    throw new UnauthorizedException("refresh token and guest id are need for refresh!");
+    throw new UnauthorizedException("로그인이 필요합니다.");
   }
 };

--- a/backend/src/service/page_service.ts
+++ b/backend/src/service/page_service.ts
@@ -493,7 +493,7 @@ export class PageService {
 		}
 
 		else if (orderBy === "chosen") {
-			count = subQuery
+			count = await subQuery
 				.select(['covers.id'])
 				.andWhere('covers.is_chosen = :is_chosen', { is_chosen: true })
 				.getCount();
@@ -503,6 +503,7 @@ export class PageService {
 				.addOrderBy('covers.id', 'DESC')
 				.limit(pageInfo.limit)
 				.offset(pageInfo.offset)
+			console.log(count);
 		}
 		return { subQuery, count };
 	}

--- a/backend/src/service/page_service.ts
+++ b/backend/src/service/page_service.ts
@@ -300,11 +300,6 @@ export class PageService {
 			const subTitle = "title" + String(i);
 			subQuery.orWhere(subStr, { [subTitle]: `%${keywords[i]}%` })
 		}
-		subQuery = await this.questionRepository
-			.createQueryBuilder('covers')
-			.select(['covers.id'])
-			.leftJoin('covers.hashtag', 'hashtag')
-			.where('hashtag.id = :id', { id: pageInfo.hashtagId })
 		const orderByData = await this.orderByList(subQuery, orderBy, pageInfo);
 		const questionCount = orderByData.count;
 		const questionList = await this.questionRepository
@@ -503,7 +498,6 @@ export class PageService {
 				.addOrderBy('covers.id', 'DESC')
 				.limit(pageInfo.limit)
 				.offset(pageInfo.offset)
-			console.log(count);
 		}
 		return { subQuery, count };
 	}

--- a/backend/src/service/page_service.ts
+++ b/backend/src/service/page_service.ts
@@ -205,7 +205,6 @@ export class PageService {
 	}
 
 	async getQuestionList(pageInfo) {
-
 		const subQuery = await this.questionRepository
 			.createQueryBuilder('covers')
 			.select(['covers.id'])
@@ -291,47 +290,28 @@ export class PageService {
 
 	async getQuestionListByKeyword(pageInfo, orderBy) {
 		const keywords = pageInfo.keyword.split(" ");
-		
 		let subQuery;
 
 		subQuery = this.questionRepository
 			.createQueryBuilder('covers')
 			.where('covers.title like :title', { title: `%${keywords[0]}%` })
-		for(let i = 1; i < keywords.length; i++){
+		for (let i = 1; i < keywords.length; i++) {
 			const subStr = 'covers.title like :title' + String(i);
-			const subTitle = "title"+ String(i);
-			subQuery.orWhere(subStr, { [subTitle] : `%${keywords[i]}%` })
+			const subTitle = "title" + String(i);
+			subQuery.orWhere(subStr, { [subTitle]: `%${keywords[i]}%` })
 		}
-
-		if (orderBy === "time"){
-		subQuery.select(['covers.id'])
-			.orderBy('covers.id', 'DESC')
-			.limit(pageInfo.limit)
-			.offset(pageInfo.offset)
-		}
-		else if (orderBy === "like"){
-		subQuery
-			.select(['covers.id', 'covers.like_count'])
-			.orderBy('covers.like_count', 'DESC')
-			.addOrderBy('covers.id', 'DESC')
-			.limit(pageInfo.limit)
-			.offset(pageInfo.offset)
-		}
-
-		else if (orderBy === "solving"){
-		subQuery 
-			.select(['covers.id', 'covers.like_count'])
-			.andWhere('covers.is_solved = :is_solved', { is_solved: false })
-			.addOrderBy('covers.id', 'DESC')
-			.limit(pageInfo.limit)
-			.offset(pageInfo.offset)
-		}
-
+		subQuery = await this.questionRepository
+			.createQueryBuilder('covers')
+			.select(['covers.id'])
+			.leftJoin('covers.hashtag', 'hashtag')
+			.where('hashtag.id = :id', { id: pageInfo.hashtagId })
+		const orderByData = await this.orderByList(subQuery, orderBy, pageInfo);
+		const questionCount = orderByData.count;
 		const questionList = await this.questionRepository
 			.createQueryBuilder('question')
-			.innerJoin(`(${subQuery.getQuery()})`, 'covers',
+			.innerJoin(`(${orderByData.subQuery.getQuery()})`, 'covers',
 				'question.id = covers.covers_id')
-			.setParameters(subQuery.getParameters())
+			.setParameters(orderByData.subQuery.getParameters())
 			.innerJoinAndSelect('question.user', 'question_user')
 			.leftJoin('question.hashtag', 'question_hashtag')
 			.select(['question.id', 'question.created_at', 'question.is_solved', 'question.like_count', 'question.view_count', 'question.answer_count', 'question.title', 'question.text',
@@ -340,142 +320,157 @@ export class PageService {
 			])
 			.orderBy('question.id', 'DESC')
 			.getMany();
-
-		const questionCount = await this.questionRepository
-			.createQueryBuilder('question')
-			.where('question.title like :title', { title: `%${pageInfo.keyword}%` })
-			.getCount();
 		return { questionList, questionCount }
 	}
 
 	async getQuestionListByHashtagId(pageInfo, orderBy): Promise<any> {
 		let subQuery;
 
-        subQuery = await this.questionRepository
-            .createQueryBuilder('covers')
-            .select(['covers.id'])
-            .leftJoin('covers.hashtag', 'hashtag')
-            .where('hashtag.id = :id', { id: pageInfo.hashtagId })
-	
-		if (orderBy === "time"){
-			subQuery.select(['covers.id'])
-				.orderBy('covers.id', 'DESC')
-				.limit(pageInfo.limit)
-				.offset(pageInfo.offset)
-		}
-		else if (orderBy === "like"){
-			subQuery
-				.select(['covers.id', 'covers.like_count'])
-				.orderBy('covers.like_count', 'DESC')
-				.addOrderBy('covers.id', 'DESC')
-				.limit(pageInfo.limit)
-				.offset(pageInfo.offset)
-		}
-	
-		else if (orderBy === "solving"){
-			subQuery 
-				.select(['covers.id', 'covers.like_count'])
-				.andWhere('covers.is_solved = :is_solved', { is_solved: false })
-				.addOrderBy('covers.id', 'DESC')
-				.limit(pageInfo.limit)
-				.offset(pageInfo.offset)
-		}
+		subQuery = await this.questionRepository
+			.createQueryBuilder('covers')
+			.select(['covers.id'])
+			.leftJoin('covers.hashtag', 'hashtag')
+			.where('hashtag.id = :id', { id: pageInfo.hashtagId })
 
-        const questionList = await this.questionRepository
-            .createQueryBuilder('question')
-            .innerJoin(`(${subQuery.getQuery()})`, 'covers',
-                'question.id = covers.covers_id')
-            .setParameters(subQuery.getParameters())
-            .innerJoinAndSelect('question.user', 'question_user')
-            .leftJoin('question.hashtag', 'question_hashtag')
-            .select(['question.id', 'question.created_at', 'question.is_solved', 'question.like_count', 'question.view_count', 'question.answer_count', 'question.title', 'question.text',
-                'question_user.id', 'question_user.created_at', 'question_user.email', 'question_user.nickname', 'question_user.photo',
-                'question_hashtag.id', 'question_hashtag.name'
-            ])
-            .getMany();
-
-        const questionCount = await this.hashtagRepository
-            .createQueryBuilder('hashtag')
-            .leftJoinAndSelect('hashtag.question', 'question')
-            .where('hashtag.name = :name', { name: pageInfo.hashtag })
-            .select('COUNT(*) AS count')
-            .getRawOne();
-
-        return { questionList, questionCount: questionCount.count };
-    }
+		const orderByData = await this.orderByList(subQuery, orderBy, pageInfo);
+		const questionCount = orderByData.count;
+		const questionList = await this.questionRepository
+			.createQueryBuilder('question')
+			.innerJoin(`(${orderByData.subQuery.getQuery()})`, 'covers',
+				'question.id = covers.covers_id')
+			.setParameters(orderByData.subQuery.getParameters())
+			.innerJoinAndSelect('question.user', 'question_user')
+			.leftJoin('question.hashtag', 'question_hashtag')
+			.select(['question.id', 'question.created_at', 'question.is_solved', 'question.like_count', 'question.view_count', 'question.answer_count', 'question.title', 'question.text',
+				'question_user.id', 'question_user.created_at', 'question_user.email', 'question_user.nickname', 'question_user.photo',
+				'question_hashtag.id', 'question_hashtag.name'
+			])
+			.getMany();
+		return { questionList, questionCount };
+	}
 
 	async getQuestionListByHashtagName(pageInfo, orderBy): Promise<any> {
 		let subQuery;
 
-        subQuery = await this.questionRepository
-            .createQueryBuilder('covers')
-            .select(['covers.id'])
-            .leftJoin('covers.hashtag', 'hashtag')
-            .where('hashtag.name = :name', { name: pageInfo.hashtagName })
-	
-		if (orderBy === "time"){
-			subQuery.select(['covers.id'])
-				.orderBy('covers.id', 'DESC')
-				.limit(pageInfo.limit)
-				.offset(pageInfo.offset)
-		}
-		else if (orderBy === "like"){
-			subQuery
-				.select(['covers.id', 'covers.like_count'])
-				.orderBy('covers.like_count', 'DESC')
-				.addOrderBy('covers.id', 'DESC')
-				.limit(pageInfo.limit)
-				.offset(pageInfo.offset)
-		}
-	
-		else if (orderBy === "solving"){
-			subQuery 
-				.select(['covers.id', 'covers.like_count'])
-				.andWhere('covers.is_solved = :is_solved', { is_solved: false })
-				.addOrderBy('covers.id', 'DESC')
-				.limit(pageInfo.limit)
-				.offset(pageInfo.offset)
-		}
-
-        const questionList = await this.questionRepository
-            .createQueryBuilder('question')
-            .innerJoin(`(${subQuery.getQuery()})`, 'covers',
-                'question.id = covers.covers_id')
-            .setParameters(subQuery.getParameters())
-            .innerJoinAndSelect('question.user', 'question_user')
-            .leftJoin('question.hashtag', 'question_hashtag')
-            .select(['question.id', 'question.created_at', 'question.is_solved', 'question.like_count', 'question.view_count', 'question.answer_count', 'question.title', 'question.text',
-                'question_user.id', 'question_user.created_at', 'question_user.email', 'question_user.nickname', 'question_user.photo',
-                'question_hashtag.id', 'question_hashtag.name'
-            ])
-            .getMany();
-
-        const questionCount = await await this.hashtagRepository
-            .createQueryBuilder('hashtag')
-            .leftJoinAndSelect('hashtag.question', 'question')
-            .where('hashtag.name = :name', { name: pageInfo.hashtag })
-            .select('COUNT(*) AS count')
-            .getRawOne();
-
-        return { questionList, questionCount: questionCount.count };
-    }
+		subQuery = await this.questionRepository
+			.createQueryBuilder('covers')
+			.select(['covers.id'])
+			.leftJoin('covers.hashtag', 'hashtag')
+			.where('hashtag.name = :name', { name: pageInfo.hashtagName })
+		const orderByData = await this.orderByList(subQuery, orderBy, pageInfo);
+		const questionCount = orderByData.count;
+		const questionList = await this.questionRepository
+			.createQueryBuilder('question')
+			.innerJoin(`(${orderByData.subQuery.getQuery()})`, 'covers',
+				'question.id = covers.covers_id')
+			.setParameters(orderByData.subQuery.getParameters())
+			.innerJoinAndSelect('question.user', 'question_user')
+			.leftJoin('question.hashtag', 'question_hashtag')
+			.select(['question.id', 'question.created_at', 'question.is_solved', 'question.like_count', 'question.view_count', 'question.answer_count', 'question.title', 'question.text',
+				'question_user.id', 'question_user.created_at', 'question_user.email', 'question_user.nickname', 'question_user.photo',
+				'question_hashtag.id', 'question_hashtag.name'
+			])
+			.getMany();
+		return { questionList, questionCount };
+	}
 
 	async getQuestionListByUserId(pageInfo, orderBy): Promise<any> {
 		let subQuery;
 
-        subQuery = await this.questionRepository
-            .createQueryBuilder('covers')
-            .select(['covers.id'])
-            .leftJoin('covers.user', 'user')
-            .where('user.id = :id', { id: pageInfo.userId })
-	
-		if (orderBy === "time"){
+		subQuery = await this.questionRepository
+			.createQueryBuilder('covers')
+			.select(['covers.id'])
+			.leftJoin('covers.user', 'user')
+			.where('user.id = :id', { id: pageInfo.userId })
+
+		const orderByData = await this.orderByList(subQuery, orderBy, pageInfo);
+		const questionCount = orderByData.count;
+		const questionList = await this.questionRepository
+			.createQueryBuilder('question')
+			.innerJoin(`(${orderByData.subQuery.getQuery()})`, 'covers',
+				'question.id = covers.covers_id')
+			.setParameters(orderByData.subQuery.getParameters())
+			.innerJoinAndSelect('question.user', 'question_user')
+			.leftJoin('question.hashtag', 'question_hashtag')
+			.select(['question.id', 'question.created_at', 'question.is_solved', 'question.like_count', 'question.view_count', 'question.answer_count', 'question.title', 'question.text',
+				'question_user.id', 'question_user.created_at', 'question_user.email', 'question_user.nickname', 'question_user.photo',
+				'question_hashtag.id', 'question_hashtag.name'
+			])
+			.getMany();
+		return { questionList, questionCount };
+	}
+
+	async getAnswerListByUserId(pageInfo, orderBy): Promise<any> {
+		let subQuery;
+
+		subQuery = await this.answerRepository
+			.createQueryBuilder('covers')
+			.select(['covers.id'])
+			.leftJoin('covers.user', 'user')
+			.where('user.id = :id', { id: pageInfo.userId })
+
+		const orderByData = await this.orderByList(subQuery, orderBy, pageInfo);
+		const answerCount = orderByData.count;
+		const answerList = await this.answerRepository
+			.createQueryBuilder('answer')
+			.innerJoin(`(${orderByData.subQuery.getQuery()})`, 'covers',
+				'answer.id = covers.covers_id')
+			.setParameters(orderByData.subQuery.getParameters())
+			.innerJoinAndSelect('answer.user', 'answer_user')
+			.select(['answer.id', 'answer.created_at', 'answer.like_count', 'answer.text',
+				'answer_user.id', 'answer_user.created_at', 'answer_user.email', 'answer_user.nickname', 'answer_user.photo',
+			])
+			.getMany();
+		return { answerList, answerCount };
+	}
+
+	async getCommentListByUserId(pageInfo): Promise<any> {
+		const subQuery = await this.commentRepository
+			.createQueryBuilder('covers')
+			.select(['covers.id'])
+			.leftJoin('covers.user', 'user')
+			.where('user.id = :id', { id: pageInfo.userId })
+			.orderBy('covers.id', 'DESC')
+			.limit(pageInfo.limit)
+			.offset(pageInfo.offset)
+
+		const commentList = await this.commentRepository
+			.createQueryBuilder('comment')
+			.innerJoin(`(${subQuery.getQuery()})`, 'covers',
+				'comment.id = covers.covers_id')
+			.setParameters(subQuery.getParameters())
+			.innerJoinAndSelect('comment.user', 'comment_user')
+			.select(['comment.id', 'comment.created_at', 'comment.text',
+				'comment_user.id', 'comment_user.created_at', 'comment_user.email', 'comment_user.nickname', 'comment_user.photo',
+			])
+			.getMany();
+
+		const commentCount = await this.userRepository
+			.createQueryBuilder('user')
+			.leftJoinAndSelect('user.comment', 'comment')
+			.where('user.id = :id', { id: pageInfo.userId })
+			.select('COUNT(*) AS count')
+			.getRawOne();
+
+		return { commentList, commentCount: commentCount.count };
+	}
+
+	async orderByList(subQuery, orderBy: string, pageInfo) {
+		let count = 0;
+
+		if (orderBy === "time") {
+			count = await subQuery
+				.select(['covers.id'])
+				.getCount();
 			subQuery.select(['covers.id'])
 				.orderBy('covers.id', 'DESC')
 				.limit(pageInfo.limit)
 				.offset(pageInfo.offset)
 		}
-		else if (orderBy === "like"){
+		else if (orderBy === "like") {
+			count = await subQuery
+				.select(['covers.id'])
+				.getCount();
 			subQuery
 				.select(['covers.id', 'covers.like_count'])
 				.orderBy('covers.like_count', 'DESC')
@@ -483,9 +478,13 @@ export class PageService {
 				.limit(pageInfo.limit)
 				.offset(pageInfo.offset)
 		}
-	
-		else if (orderBy === "solving"){
-			subQuery 
+
+		else if (orderBy === "solving") {
+			count = await subQuery
+				.select(['covers.id'])
+				.andWhere('covers.is_solved = :is_solved', { is_solved: false })
+				.getCount();
+			subQuery
 				.select(['covers.id'])
 				.andWhere('covers.is_solved = :is_solved', { is_solved: false })
 				.addOrderBy('covers.id', 'DESC')
@@ -493,111 +492,18 @@ export class PageService {
 				.offset(pageInfo.offset)
 		}
 
-        const questionList = await this.questionRepository
-            .createQueryBuilder('question')
-            .innerJoin(`(${subQuery.getQuery()})`, 'covers',
-                'question.id = covers.covers_id')
-            .setParameters(subQuery.getParameters())
-            .innerJoinAndSelect('question.user', 'question_user')
-            .leftJoin('question.hashtag', 'question_hashtag')
-            .select(['question.id', 'question.created_at', 'question.is_solved', 'question.like_count', 'question.view_count', 'question.answer_count', 'question.title', 'question.text',
-                'question_user.id', 'question_user.created_at', 'question_user.email', 'question_user.nickname', 'question_user.photo',
-                'question_hashtag.id', 'question_hashtag.name'
-            ])
-            .getMany();
-
-        const questionCount = await await this.userRepository
-            .createQueryBuilder('user')
-            .leftJoinAndSelect('user.question', 'question')
-            .where('user.id = :id', { id: pageInfo.userId })
-            .select('COUNT(*) AS count')
-            .getRawOne();
-
-        return { questionList, questionCount: questionCount.count };
-    }
-
-	async getAnswerListByUserId(pageInfo, orderBy): Promise<any> {
-		let subQuery;
-
-        subQuery = await this.answerRepository
-            .createQueryBuilder('covers')
-            .select(['covers.id'])
-            .leftJoin('covers.user', 'user')
-            .where('user.id = :id', { id: pageInfo.userId })
-	
-		if (orderBy === "time"){
-			subQuery.select(['covers.id'])
-				.orderBy('covers.id', 'DESC')
-				.limit(pageInfo.limit)
-				.offset(pageInfo.offset)
-		}
-		else if (orderBy === "like"){
+		else if (orderBy === "chosen") {
+			count = subQuery
+				.select(['covers.id'])
+				.andWhere('covers.is_chosen = :is_chosen', { is_chosen: true })
+				.getCount();
 			subQuery
-				.select(['covers.id', 'covers.like_count'])
-				.orderBy('covers.like_count', 'DESC')
-				.addOrderBy('covers.id', 'DESC')
-				.limit(pageInfo.limit)
-				.offset(pageInfo.offset)
-		}
-	
-		else if (orderBy === "chosen"){
-			subQuery 
 				.select(['covers.id', 'covers.like_count'])
 				.andWhere('covers.is_chosen = :is_chosen', { is_chosen: true })
 				.addOrderBy('covers.id', 'DESC')
 				.limit(pageInfo.limit)
 				.offset(pageInfo.offset)
 		}
-
-        const answerList = await this.answerRepository
-            .createQueryBuilder('answer')
-            .innerJoin(`(${subQuery.getQuery()})`, 'covers',
-                'answer.id = covers.covers_id')
-            .setParameters(subQuery.getParameters())
-            .innerJoinAndSelect('answer.user', 'answer_user')
-            .select(['answer.id', 'answer.created_at', 'answer.like_count', 'answer.text',
-                'answer_user.id', 'answer_user.created_at', 'answer_user.email', 'answer_user.nickname', 'answer_user.photo',
-            ])
-            .getMany();
-
-        const answerCount = await await this.userRepository
-            .createQueryBuilder('user')
-            .leftJoinAndSelect('user.answer', 'answer')
-            .where('user.id = :id', { id: pageInfo.userId })
-            .select('COUNT(*) AS count')
-            .getRawOne();
-
-        return { answerList, answerCount: answerCount.count };
-    }
-
-	async getCommentListByUserId(pageInfo): Promise<any> {
-        const subQuery = await this.commentRepository
-            .createQueryBuilder('covers')
-            .select(['covers.id'])
-            .leftJoin('covers.user', 'user')
-            .where('user.id = :id', { id: pageInfo.userId })
-			.orderBy('covers.id', 'DESC')
-			.limit(pageInfo.limit)
-			.offset(pageInfo.offset)
-
-        const commentList = await this.commentRepository
-            .createQueryBuilder('comment')
-            .innerJoin(`(${subQuery.getQuery()})`, 'covers',
-                'comment.id = covers.covers_id')
-            .setParameters(subQuery.getParameters())
-            .innerJoinAndSelect('comment.user', 'comment_user')
-            .select(['comment.id', 'comment.created_at', 'comment.text',
-                'comment_user.id', 'comment_user.created_at', 'comment_user.email', 'comment_user.nickname', 'comment_user.photo',
-            ])
-            .getMany();
-
-        const commentCount = await await this.userRepository
-            .createQueryBuilder('user')
-            .leftJoinAndSelect('user.comment', 'comment')
-            .where('user.id = :id', { id: pageInfo.userId })
-            .select('COUNT(*) AS count')
-            .getRawOne();
-
-        return { commentList, commentCount: commentCount.count };
-    }
+		return { subQuery, count };
+	}
 }


### PR DESCRIPTION
## 개요
#308

## 작업사항
- 정렬코드 중복 제거 
![image](https://user-images.githubusercontent.com/48669085/146032513-e26d5ce0-a3d2-48fa-8074-7069b3b50146.png)
위의 그림에 있는 API에는 
![image](https://user-images.githubusercontent.com/48669085/146028293-283ee322-9c0b-4ac7-be97-1c5ea380fcf5.png)
와같은 중복 코드를 삭제함

- 답변 필요 질문글 리스트 API 잘못된 questionCount 응답 수정
검색필터에 상관없이 항상 전체 갯수를 가져오는 문제를 해결함
